### PR TITLE
fix click event in 1.19.3

### DIFF
--- a/plugin/src/main/java/cz/boosik/boosCooldown/BoosCoolDownListener.java
+++ b/plugin/src/main/java/cz/boosik/boosCooldown/BoosCoolDownListener.java
@@ -213,6 +213,17 @@ public class BoosCoolDownListener implements Listener {
             for (final String key : commandQueue.keySet()) {
                 final String[] keyList = key.split("@");
                 if (keyList[0].equals(String.valueOf(uuid))) {
+                    if (event.getMessage().contains(BoosConfigManager.getConfirmCommandMessage())) {
+                        commandQueue.put(key, true);
+                        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
+                            @Override
+                            public void run() {
+                                player.chat(keyList[1]);
+                            }
+                        });
+                        event.setCancelled(true);
+                        return;
+                    }
                     if (!keyList[1].equals(event.getMessage())) {
                         commandQueue.remove(key);
                         String commandCancelMessage = BoosConfigManager.getCommandCanceledMessage();


### PR DESCRIPTION
According to the wiki, the run_command must be prefixed with a "/" and parsed as a command.
I added the code to the command event and now it is optional to change the confirm command in config.yml to /yes to allow clicks, or keep the existing one that requires player input.
great plugin, thank you